### PR TITLE
feat: add code delivered while on the exercise

### DIFF
--- a/src/CurrenciesScreen.tsx
+++ b/src/CurrenciesScreen.tsx
@@ -8,6 +8,10 @@ export const CurrenciesScreen = () => {
   const { data, isLoading, isError } = useCurrencies();
   const [filteredData, setFilteredData] = useState<Currencies>([]);
   const [showTestMode, setShowTestMode] = useState(false);
+  const [sortBy, setSortBy] = useState<"name" | "code">();
+
+  const sortByName = () => setSortBy("name");
+  const sortByCode = () => setSortBy("code");
 
   useEffect(() => {
     if (showTestMode) {
@@ -16,6 +20,19 @@ export const CurrenciesScreen = () => {
       setFilteredData(data);
     }
   }, [data, showTestMode]);
+
+  useEffect(() => {
+    if (sortBy === "name") {
+      // Create new array to avoid mutating in place and to trigger a re-render
+      setFilteredData((prevState) => [
+        ...prevState.sort((a, b) => (a.name > b.name ? 1 : -1)),
+      ]);
+    } else if (sortBy === "code") {
+      setFilteredData((prevState) => [
+        ...prevState.sort((a, b) => (a.code > b.code ? 1 : -1)),
+      ]);
+    }
+  }, [sortBy]);
 
   if (isLoading) {
     return <Text testID="loading">Loading...</Text>;
@@ -41,7 +58,12 @@ export const CurrenciesScreen = () => {
         data={filteredData}
         renderItem={({ item }) => <CurrenciesListItem item={item} />}
         keyExtractor={(item) => item.code}
-        ListHeaderComponent={<CurrenciesListHeader />}
+        ListHeaderComponent={() => (
+          <CurrenciesListHeader
+            onNamePress={sortByName}
+            onCodePress={sortByCode}
+          />
+        )}
       />
     </View>
   );

--- a/src/CurrenciesScreen.tsx
+++ b/src/CurrenciesScreen.tsx
@@ -1,9 +1,10 @@
 import React from "react";
-import { StyleSheet, Text, View } from "react-native";
+import { FlatList, StyleSheet, Text, View } from "react-native";
+import { CurrenciesListHeader, CurrenciesListItem } from "./components";
 import { useCurrencies } from "./hooks/useCurrencies";
 
 export const CurrenciesScreen = () => {
-  const { isLoading, isError } = useCurrencies();
+  const { data, isLoading, isError } = useCurrencies();
 
   if (isLoading) {
     return <Text testID="loading">Loading...</Text>;
@@ -16,6 +17,12 @@ export const CurrenciesScreen = () => {
   return (
     <View testID="container">
       <Text>Currencies should be listed below</Text>
+      <FlatList
+        data={data}
+        renderItem={({ item }) => <CurrenciesListItem item={item} />}
+        keyExtractor={(item) => item.code}
+        ListHeaderComponent={<CurrenciesListHeader />}
+      />
     </View>
   );
 };

--- a/src/CurrenciesScreen.tsx
+++ b/src/CurrenciesScreen.tsx
@@ -1,10 +1,21 @@
-import React from "react";
-import { FlatList, StyleSheet, Text, View } from "react-native";
+import React, { useEffect, useState } from "react";
+import { FlatList, StyleSheet, Switch, Text, View } from "react-native";
 import { CurrenciesListHeader, CurrenciesListItem } from "./components";
 import { useCurrencies } from "./hooks/useCurrencies";
+import { Currencies } from "./types";
 
 export const CurrenciesScreen = () => {
   const { data, isLoading, isError } = useCurrencies();
+  const [filteredData, setFilteredData] = useState<Currencies>([]);
+  const [showTestMode, setShowTestMode] = useState(false);
+
+  useEffect(() => {
+    if (showTestMode) {
+      setFilteredData(data.filter((item) => item.supportsTestMode));
+    } else {
+      setFilteredData(data);
+    }
+  }, [data, showTestMode]);
 
   if (isLoading) {
     return <Text testID="loading">Loading...</Text>;
@@ -16,9 +27,18 @@ export const CurrenciesScreen = () => {
 
   return (
     <View testID="container">
-      <Text>Currencies should be listed below</Text>
+      <View>
+        <Text>Toggle test mode filtering</Text>
+        <Switch
+          trackColor={{ false: "#767577", true: "#81b0ff" }}
+          thumbColor={showTestMode ? "#f5dd4b" : "#f4f3f4"}
+          ios_backgroundColor="#3e3e3e"
+          onValueChange={setShowTestMode}
+          value={showTestMode}
+        />
+      </View>
       <FlatList
-        data={data}
+        data={filteredData}
         renderItem={({ item }) => <CurrenciesListItem item={item} />}
         keyExtractor={(item) => item.code}
         ListHeaderComponent={<CurrenciesListHeader />}

--- a/src/CurrenciesScreen.tsx
+++ b/src/CurrenciesScreen.tsx
@@ -14,10 +14,12 @@ export const CurrenciesScreen = () => {
   const sortByCode = () => setSortBy("code");
 
   useEffect(() => {
-    if (showTestMode) {
-      setFilteredData(data.filter((item) => item.supportsTestMode));
-    } else {
-      setFilteredData(data);
+    if (data) {
+      if (showTestMode) {
+        setFilteredData(data.filter((item) => item.supportsTestMode));
+      } else {
+        setFilteredData(data);
+      }
     }
   }, [data, showTestMode]);
 
@@ -47,6 +49,7 @@ export const CurrenciesScreen = () => {
       <View>
         <Text>Toggle test mode filtering</Text>
         <Switch
+          testID="switchToggle"
           trackColor={{ false: "#767577", true: "#81b0ff" }}
           thumbColor={showTestMode ? "#f5dd4b" : "#f4f3f4"}
           ios_backgroundColor="#3e3e3e"

--- a/src/components/CurrenciesListHeader.tsx
+++ b/src/components/CurrenciesListHeader.tsx
@@ -27,7 +27,6 @@ const styles = StyleSheet.create({
   container: {
     flexDirection: "row",
     justifyContent: "space-evenly",
-
     backgroundColor: "#f4f4f4",
     borderBottomWidth: 1,
     borderColor: "#ddd",

--- a/src/components/CurrenciesListItem.tsx
+++ b/src/components/CurrenciesListItem.tsx
@@ -23,7 +23,7 @@ export const CurrenciesListItem: React.FC<ICurrenciesListItemProps> = ({
 const styles = StyleSheet.create({
   container: {
     flexDirection: "row",
-    justifyContent: "space-between",
+    justifyContent: "space-evenly",
     padding: 10,
     borderBottomWidth: 1,
     borderColor: "#ddd",

--- a/src/tests/CurrenciesScreen.test.tsx
+++ b/src/tests/CurrenciesScreen.test.tsx
@@ -27,7 +27,7 @@ describe("CurrenciesScreen", () => {
   it("should display error message when there is an error fetching data", () => {
     // Arrange
     const useCurrenciesMock = jest
-      .spyOn(require("./hooks/useCurrencies"), "useCurrencies")
+      .spyOn(require("../hooks/useCurrencies"), "useCurrencies")
       .mockReturnValueOnce({
         data: null,
         isLoading: false,

--- a/src/tests/CurrenciesScreen.test.tsx
+++ b/src/tests/CurrenciesScreen.test.tsx
@@ -1,5 +1,24 @@
-import { screen, render, waitFor } from "@testing-library/react-native";
+import {
+  screen,
+  render,
+  waitFor,
+  act,
+  fireEvent,
+} from "@testing-library/react-native";
 import { CurrenciesScreen } from "../CurrenciesScreen";
+
+const mockData = [
+  {
+    code: "BTC",
+    name: "Bitcoin",
+    supportsTestMode: true,
+  },
+  {
+    code: "ADA",
+    name: "Cardano",
+    supportsTestMode: false,
+  },
+];
 
 describe("CurrenciesScreen", () => {
   it("should display loading indicator when data is being fetched", () => {
@@ -42,6 +61,33 @@ describe("CurrenciesScreen", () => {
       const errorMessage = screen.getByTestId("error");
       expect(errorMessage).toBeTruthy();
       useCurrenciesMock.mockRestore();
+    });
+  });
+
+  describe("Filtering", () => {
+    it("should filter data based on their support of test mode", () => {
+      // Arrange
+      const useCurrenciesMock = jest
+        .spyOn(require("../hooks/useCurrencies"), "useCurrencies")
+        .mockResolvedValueOnce({
+          data: mockData,
+          isLoading: false,
+          isError: false,
+        });
+      // Arrange
+      render(<CurrenciesScreen />);
+
+      // Act
+      act(() => {
+        fireEvent.press(screen.getByTestId("switchToggle"));
+      });
+
+      // Assert
+      waitFor(() => {
+        const result = screen.getByText("false");
+        expect(result).toHaveLength(0);
+        useCurrenciesMock.mockRestore();
+      });
     });
   });
 });


### PR DESCRIPTION
## Description

There were 4 tasks for this test:
1. Display list of currencies using provided components
2. Add a component to toggle between filtering elements that are not supported on testmode (if false show all, if true only the ones that are supported)
3. Add list sorting by `name` or `code` 
4. Add test to assert if filtering feature is working

## Implementation details
Below I'm trying to replicate the reasoning shared while pairing on the meeting as faithfully as I can remember
 
### Display of list of currencies

Went for `FlatList` component since it had all I needed for this exercise. No need to develop data fetching or anything since that was already provided by the template.

### Filtering

Initially, I thought about using a `Pressable` component to toggle states. This would have been good in case we needed to create our own toggling component. However, as said by Iacopo, we didn't need that UI refinement so I went to the [ReactNative docs](https://reactnative.dev/docs/components-and-apis) to pull [the sample code for the `Switch`
component](https://reactnative.dev/docs/switch#example) and use that instead. A few minor modifications were needed since code was different but it was basically it.

Wanted to make a row `View` as well to put the text alongside it but during the exercise it was expressed the lack of need of that so it was left as a column container which doesn't make much sense visually but works for the test.


### Sorting

This step of the exercise was very troubling while working on it in the heat of the moment. My first thought while doing it was to use the `prevState` prop of the callback to avoid any cyclic dependencies with `filteredData` (since it would be changed by the effect and then it
would retrigger it). However, I was biased by the continuous usage of ESLint on the projects I worked were dependencies need to be put there always so I got used to this (since I still thing it's usually a good practice).

In the scope of this exercise, such check was not needed so the easiest way to develop it was to change `filteredData`.

The approach I took, I was mutating the `prevState` element in place (by the function sort). So this would not trigger a re-render on the page which would resort in an unexpected UX.

The final workaround was to destruct the mutated element inside a new array, effectively copying it and thus forcing a re-render of the page.

### Testing

The easiest way, although flawed, was to check the screen for any `false` texts since they should have been filtered and not be rendered.

This is a bad test since it could happen that an element of the list has either a name or code "false" so it would trigger a false negative.

Discussing with the team, they asked me if I was familiar with `@testing-library` (to which I replied I used just a few times) because there is a built-in function which is better suited for this.

After a quick google search while I was been told that it was no longer needed I recalled that there's a `queryByText` function which would have been better suited to test the lack of element in the screen.


## Demo

| <video src='https://github.com/user-attachments/assets/6d46bac2-1975-46b8-b282-47732484c3d5'>  |
| :--: |

| _Test run_ |
| :--: |
| <img width="578" alt="image" src="https://github.com/user-attachments/assets/eeefb7d4-656d-4ed2-9d47-9710d681beda"> |
